### PR TITLE
0.0.40

### DIFF
--- a/cantok/tokens/timeout_token.py
+++ b/cantok/tokens/timeout_token.py
@@ -1,4 +1,4 @@
-from time import monotonic_ns, perf_counter
+import time
 from typing import Any, Callable, Dict, Optional, Union
 
 from cantok import AbstractToken, ConditionToken
@@ -40,9 +40,9 @@ class TimeoutToken(ConditionToken):
         timer: Callable[[], Union[int, float]]
         if monotonic:
             timeout *= 1_000_000_000
-            timer = monotonic_ns
+            timer = time.monotonic_ns
         else:
-            timer = perf_counter
+            timer = time.perf_counter
 
         start_time: Union[int, float] = timer()
         deadline = start_time + timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cantok"
-version = "0.0.39"
+version = "0.0.40"
 authors = [{ name = "Evgeniy Blinov", email = "zheni-b@yandex.ru" }]
 description = 'Implementation of the "Cancellation Token" pattern'
 readme = "README.md"

--- a/tests/units/tokens/abstract/test_abstract_token.py
+++ b/tests/units/tokens/abstract/test_abstract_token.py
@@ -1,3 +1,4 @@
+import time
 from functools import partial
 from threading import Thread
 from time import perf_counter, sleep
@@ -504,7 +505,7 @@ def test_cached_nested_cancellation_report_does_not_override_later_parent_superp
     assert exc_info.value.token is token
 
     current_time = 0.0
-    monkeypatch.setattr('cantok.tokens.timeout_token.perf_counter', lambda: current_time)
+    monkeypatch.setattr(time, 'perf_counter', lambda: current_time)
     token = TimeoutToken(1, nested_token, doc='parent-doc')
 
     assert token.cancelled

--- a/tests/units/tokens/test_timeout_token.py
+++ b/tests/units/tokens/test_timeout_token.py
@@ -1,3 +1,4 @@
+import time
 from time import perf_counter, sleep
 
 import pytest
@@ -102,6 +103,34 @@ def test_timeout_expired(options):
     assert token.is_cancelled() == True
     assert token.keep_on() == False
     assert token.keep_on() == False
+
+
+@pytest.mark.parametrize(
+    ('monotonic', 'clock_name', 'expired_time'),
+    [
+        (False, 'perf_counter', 1.1),
+        (True, 'monotonic_ns', 1_100_000_000),
+    ],
+)
+def test_timeout_token_clock_can_be_patched_through_time_module(monkeypatch, monotonic, clock_name, expired_time):
+    """
+    `TimeoutToken` reads its clock through the standard `time` module.
+
+    Patching the public clock function before construction must control both
+    the deadline calculation and later cancellation checks without reaching
+    into `cantok.tokens.timeout_token` internals.
+    """
+    current_time = 0.0
+
+    monkeypatch.setattr(time, clock_name, lambda: current_time)
+
+    token = TimeoutToken(1, monotonic=monotonic)
+
+    assert token.cancelled == False
+
+    current_time = expired_time
+
+    assert token.cancelled == True
 
 
 def test_text_representaion_of_extra_kwargs():


### PR DESCRIPTION
It's now easier to patch `TimeoutToken`.

Closes #55.